### PR TITLE
Fix edge case with files that have no package declaration

### DIFF
--- a/compiler-plugin/src/main/kotlin/yairm210/purity/boilerplate/PurityCommandLineProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/yairm210/purity/boilerplate/PurityCommandLineProcessor.kt
@@ -57,7 +57,7 @@ class PurityCommandLineProcessor : CommandLineProcessor {
         ),
     )
     
-    private fun stringToSet(string:String) = string.split("_").map { it.trim() }.toSet()
+    private fun stringToSet(string:String) = string.split("_").map { it.trim() }.filter { it.isNotEmpty() }.toSet()
 
     private fun getConfig(configuration: CompilerConfiguration): PurityConfig {
         val currentValue = configuration.get(KEY_PURITY_CONFIG)


### PR DESCRIPTION
Fixed an edge case for files without package declarations (e.x. happens with the Desktop Compose template in IntelliJ).

Closes #48